### PR TITLE
hkml_write: Fallback to user.email is sendemail.from is empty

### DIFF
--- a/src/hkml_write.py
+++ b/src/hkml_write.py
@@ -54,10 +54,14 @@ def format_mbox(subject, in_reply_to, to, cc, body, from_=None, draft=None):
     if not cc:
         cc = ['/* wrtite cc recipients here */']
     if from_ is None:
-        try:
-            from_ = subprocess.check_output(
-                    ['git', 'config', 'sendemail.from']).decode().strip()
-        except:
+        for conf in ['sendemail.from', 'user.email']:
+            try:
+                from_ = subprocess.check_output(
+                        ['git', 'config', conf]).decode().strip()
+            except:
+                pass
+
+        if from_ is None:
             from_ = '/* fill up please */'
 
     lines.append('Subject: %s' % subject)


### PR DESCRIPTION
Without this patch I can't send emails using msmtp, since it can't find the "from:" information. If user.email is also empty (which should be not from people using SoB on their patches), keep the placeholder text.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
