### PR TITLE
Fix saving a patch to a different filesystem than /tmp

### DIFF
--- a/src/hkml_patch.py
+++ b/src/hkml_patch.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0
 
 import os
+import shutil
 import subprocess
 import tempfile
 
@@ -68,7 +69,7 @@ def move_patches(patch_files, dest_dir):
     if dest_dir is not None:
         for patch_file in patch_files:
             basename = os.path.basename(patch_file)
-            os.rename(patch_file, os.path.join(dest_dir, basename))
+            shutil.move(patch_file, os.path.join(dest_dir, basename))
         os.rmdir(saved_dir)
         saved_dir = dest_dir
     print('\npatch files are saved at \'%s\'\n' % saved_dir)


### PR DESCRIPTION
*Issue #, if available:*
#9 

*Description of changes:*
`os.rename()` does not support this, see https://docs.python.org/3/library/os.html

We need to use `shutil.move()`

I left the one in `hkml_cache.py` unmodified, as surely no one will put split the HKML cache directory across different filesystems.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
