### PR TITLE
Fix repo branch name to display CI results properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
 
 jobs:


### PR DESCRIPTION
I do not know how to test this properly outside of merging it and checking, but let's see. If nothing else, branch name needs to be fixed