### PR TITLE
Fix typos

### DIFF
--- a/src/hkml_send.py
+++ b/src/hkml_send.py
@@ -24,7 +24,7 @@ def draft_or_sent_mail(draft_file, msgid):
     for line in header_lines:
         if line.startswith('Date: '):
             has_date = True
-        if line.startswith('Messagge-ID: '):
+        if line.startswith('Message-ID: '):
             has_msgid = True
         if line.startswith('From: '):
             has_from = True
@@ -52,7 +52,7 @@ def handle_user_edit_mistakes(tmp_path):
     for line in header.split('\n'):
         if line in [
                 'To: /* write recipients here and REMOVE this comment */',
-                'Cc: /* wrtite cc recipients here and REMOVE this comment */']:
+                'Cc: /* write cc recipients here and REMOVE this comment */']:
             continue
         header_lines.append(line)
     header = '\n'.join(header_lines)

--- a/src/hkml_signature.py
+++ b/src/hkml_signature.py
@@ -35,7 +35,7 @@ def add_signature():
     err = hkml_write.open_editor(tmp_path, 'signature')
     if err is not None:
         print(err)
-        eixt(1)
+        exit(1)
     with open(tmp_path, 'r') as f:
         lines = []
         for line in f:

--- a/src/hkml_sync.py
+++ b/src/hkml_sync.py
@@ -38,7 +38,7 @@ def setup_git(hkml_dir, remote):
     git_cmd = ['git', '-C', hkml_dir]
     if subprocess.call(git_cmd + ['init']) != 0:
         print('git initializing failed')
-        eixt(1)
+        exit(1)
     if subprocess.call(
             git_cmd + ['remote', 'add', 'sync-target', remote]) != 0:
         print('adding remote failed')

--- a/src/hkml_write.py
+++ b/src/hkml_write.py
@@ -65,7 +65,7 @@ def format_mbox(subject, in_reply_to, to, cc, body, from_, draft_mail,
     if not to:
         to = ['/* write recipients here and REMOVE this comment */']
     if not cc:
-        cc = ['/* wrtite cc recipients here and REMOVE this comment */']
+        cc = ['/* write cc recipients here and REMOVE this comment */']
     if from_ is None:
         from_, err = get_git_config('sendemail.from')
         if err is not None:

--- a/tests/test_hkml_sync.py
+++ b/tests/test_hkml_sync.py
@@ -1,0 +1,29 @@
+
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
+
+import unittest
+from unittest.mock import patch
+import os
+import sys
+
+bindir = os.path.dirname(os.path.realpath(__file__))
+src_dir = os.path.join(bindir, '..', 'src')
+sys.path.append(src_dir)
+
+import hkml_sync
+
+class TestHkmlSync(unittest.TestCase):
+    @patch('hkml_sync.exit', side_effect=SystemExit)
+    def test_setup_git_remote_none(self, mock_exit):
+        with self.assertRaises(SystemExit):
+            hkml_sync.setup_git('test', None)
+    @patch('hkml_sync.subprocess.call')
+    @patch('hkml_sync.exit', side_effect=SystemExit)
+    def test_setup_git_init_fails(self, mock_call, mock_exit):
+        mock_call.return_value = 1
+        with self.assertRaises(SystemExit):
+            hkml_sync.setup_git('test', 'test')
+        
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Three functional and two comment fixes
Added unit test for one of the fixes

Tests are passing locally:
```
hackermail % tests/run.sh         
PASS unit test_hkml_common.py
PASS unit test_hkml_patch_format.py
PASS unit test_hkml_sync.py
PASS unit test_hkml_view_mails.py
PASS unit test_hkml_view_text.py
PASS unit test_hkml_view.py
```

CI succeeded as well with better hkml_sync coverage:
```
src/hkml_sync.py              67     49    27%
```