### PR TITLE
hkml_list: get_last_list return None tuple

### DIFF
--- a/src/_hkml_list_cache.py
+++ b/src/_hkml_list_cache.py
@@ -162,10 +162,12 @@ def get_last_mails_list():
 def get_last_list():
     cache = get_mails_lists_cache()
     keys = [k for k in cache if k != 'thread_output']
+    if not keys:
+        return None, None
     key = sorted(keys, key=lambda x: cache[x]['date'])[-1]
     outputs = get_cached_list_outputs(key)
     if outputs is None:
-        return None
+        return None, None
     return outputs['output'], outputs['index_to_cache_key']
 
 def get_last_thread():


### PR DESCRIPTION
- check if any keys are returned from get_mails_list_cache in get_last_list
- return tuple of None if last list is not found

When calling `hkml list` for the first time without specifying a mailing list, get_last_list unconditionally checks the [-1] index of keys causing
an IndexError. When get_last_list returns None, args_to_mails_list_data will attempt to destructure the tuple and raise a TypeError.