### PR TITLE
hkml: print help info instead of exception when no args given

### DIFF
--- a/src/hkml.py
+++ b/src/hkml.py
@@ -29,7 +29,7 @@ import hkml_signature
 
 import _hkml
 
-if len(sys.argv) > 0 and sys.argv[1] == '--cli_complete':
+if len(sys.argv) > 1 and sys.argv[1] == '--cli_complete':
     _hkml_cli_complete.handle_cli_complete()
     exit(0)
 


### PR DESCRIPTION
If you run hkml with no args given, it print a exception error:

./hkml
Traceback (most recent call last):
  File "/Volumes/Codebase/projects/hackermail/./hkml", line 32, in <module>
    if len(sys.argv) > 0 and sys.argv[1] == '--cli_complete':
                             ~~~~~~~~^^^
IndexError: list index out of range

Fix that by print the usage info instead.

Signed-off-by: Kairui Song <kasong@tencent.com>