### PR TITLE
hkml: make it easier to use with pipx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hackermail"
+version = "0.1.0"
+description = "HacKerMaiL (hkml) - a mails management tool for hackers who collaborate using mailing lists"
+license = "GPL-2.0-only"
+requires-python = ">=3.8"
+dependencies = [
+    "requests",
+]
+
+[project.scripts]
+hkml = "_hkml_entry:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/_hkml_entry.py
+++ b/src/_hkml_entry.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
+
+def main():
+    import runpy
+    runpy.run_module('hkml', run_name='__main__', alter_sys=True)


### PR DESCRIPTION
Hi SJ,

I use MacOS for my daily Linux kernel development, trying hkml isn't that easy there.

On MacOS or some distros, there is no python request lib from package manager, and it's hard to setup a global venv, using hkml globally is not cleanly doable with following error:

...
File "<path>/projects/hackermail/src/_hkml_sashiko_dev.py", line 10, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'

So add a proper project spec so pipx can install this tool and it can be used anywhere.

Now it can be installed globally using:

`pipx install .`

Pipx is the recommended tool manager.

Signed-off-by: Kairui Song <kasong@tencent.com>