### PR TITLE
[RFC] hkml_view: highlight current selected line

### DIFF
--- a/src/hkml_view.py
+++ b/src/hkml_view.py
@@ -223,6 +223,9 @@ class ScrollableList:
             elif line_idx == highlight_row:
                 self.screen.addstr(row, 0, line,
                                    highlight_color | color_attrib)
+            elif line_idx == self.focus_row:
+                self.screen.addstr(row, 0, line,
+                                   color | color_attrib | self.effect_reverse)
             else:
                 self.screen.addstr(row, 0, line, color | color_attrib)
 


### PR DESCRIPTION
On some terminals, the cursor is dimmed so it's hard to tell which line is the selected line. highlight it by reverse the backgroud color.

Let me know if there are any alternative config or design idea, thanks!