### PR TITLE
hkml_list: fix msgid location row and show mail index

### DIFF
--- a/src/_hkml_list_cache.py
+++ b/src/_hkml_list_cache.py
@@ -204,11 +204,15 @@ def set_item(key, list_data, keep_date=False):
 
     comments_lines = list_data.comments_lines
     if len(comments_lines) > 0:
-        if comments_lines[-1].startswith('# mail of the msgid is at row '):
-            fields = comments_lines[-1].split()
-            new_nr = int(fields[8]) + 1
-            new_line = ' '.join(fields[:8] + ['%d' % new_nr] + fields[9:])
-            comments_lines = comments_lines[:-1] + [new_line]
+        location_prefix = '# mail of the msgid is at row '
+        location = comments_lines[-1]
+        if location.startswith(location_prefix):
+            row_end = location.find(',', len(location_prefix))
+            if row_end != -1:
+                row = int(location[len(location_prefix):row_end]) + 1
+                location = '%s%d%s' % (
+                        location_prefix, row, location[row_end:])
+                comments_lines = comments_lines[:-1] + [location]
         mails_lines = list_data.mail_lines
         list_str = '\n'.join(comments_lines + mails_lines)
 

--- a/src/hkml_list.py
+++ b/src/hkml_list.py
@@ -1328,22 +1328,28 @@ def args_to_mails_list_data(args, suggest_manifest_update):
     if err is not None:
         return None, err
     if args.source_type == ['msgid']:
-        for line_nr, mail_idx in list_data.line_nr_mail_idx_map.items():
-            mail = list_data.mail_items[mail_idx].mail
-            # drop enclosing <>
-            mail_msgid = mail.get_msgid()[1:-1]
-            if mail_msgid in args.sources[0]:
-                lines = list_data.text.split('\n')
-                comment = '# mail of the msgid is at row %d (%s ...)' % (
-                        line_nr + list_data.len_comments + 1,
-                        lines[line_nr + list_data.len_comments][:45])
-                list_data.append_comments([comment])
-                break
+        add_msgid_location_comment(list_data, args.sources[0])
 
     hkml_cache.writeback_mails()
     _hkml_list_cache.set_item(lists_cache_key, list_data)
 
     return list_data, None
+
+def add_msgid_location_comment(list_data, source):
+    for line_nr, mail_idx in list_data.line_nr_mail_idx_map.items():
+        mail = list_data.mail_items[mail_idx].mail
+        # drop enclosing <>
+        mail_msgid = mail.get_msgid()[1:-1]
+        if mail_msgid not in source:
+            continue
+
+        # Account for this comment itself and convert to one-based row.
+        row = line_nr + list_data.len_comments + 2
+        comment = (
+                '# mail of the msgid is at row %d, mail index %d (%s ...)' %
+                (row, mail_idx, list_data.mail_lines[line_nr][:45]))
+        list_data.append_comments([comment])
+        return
 
 def print_options_for(category):
     parser = argparse.ArgumentParser(add_help=False)

--- a/tests/test_hkml_list.py
+++ b/tests/test_hkml_list.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+bindir = os.path.dirname(os.path.realpath(__file__))
+src_dir = os.path.join(bindir, '..', 'src')
+sys.path.append(src_dir)
+
+import _hkml_list_cache
+import hkml_list
+
+
+class FakeMail:
+    def __init__(self, msgid):
+        self.msgid = msgid
+
+    def get_msgid(self):
+        return self.msgid
+
+
+class TestHkmlList(unittest.TestCase):
+    def test_add_msgid_location_comment(self):
+        mail_items = [
+                SimpleNamespace(mail=FakeMail('<first@example.com>')),
+                SimpleNamespace(mail=FakeMail('<second@example.com>')),
+                SimpleNamespace(mail=FakeMail('<target@example.com>')),
+                ]
+        list_data = hkml_list.MailsListData(
+                '# one stat line\nfirst\nsecond\ntarget',
+                len_comments=1,
+                mail_items=mail_items,
+                line_nr_mail_idx_map={0: 0, 1: 1, 2: 2})
+
+        hkml_list.add_msgid_location_comment(
+                list_data, 'target@example.com')
+
+        self.assertEqual(
+                list_data.comments_lines[-1],
+                '# mail of the msgid is at row 5, mail index 2 '
+                '(target ...)')
+        self.assertEqual(list_data.text.splitlines()[4], 'target')
+
+    def test_cache_keeps_msgid_location_comment(self):
+        list_data = hkml_list.MailsListData(
+                '# one stat line\n'
+                '# mail of the msgid is at row 5, mail index 2 '
+                '(target ...)\n'
+                'first\nsecond\ntarget',
+                len_comments=2,
+                mail_items=[],
+                line_nr_mail_idx_map={})
+        cache = {}
+
+        with patch.object(
+                _hkml_list_cache, 'get_mails_lists_cache',
+                return_value=cache), \
+             patch.object(_hkml_list_cache, 'writeback_list_output'), \
+             patch.object(_hkml_list_cache, 'record_cache_creation'):
+            _hkml_list_cache.set_item('key', list_data)
+
+        self.assertIn(
+                '# mail of the msgid is at row 6, mail index 2 '
+                '(target ...)',
+                cache['key']['output'])
+        self.assertNotIn(
+                '# mail of the msgid is at row 5, mail index 2 '
+                '(target ...)',
+                cache['key']['output'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When a list is sourced from a Message-ID, hkml appends a location comment after calculating the displayed row. The comment itself shifts the target mail down by one line, so fresh output reports a row that is one too small. Cached output adds a separate marker line and needs one additional adjustment.

Fix the fresh row calculation, preserve the cache-specific adjustment using the explicit location prefix, and show the mail index accepted by `hkml open` and `hkml reply` alongside the display row. This avoids mistaking a display row for a command index.

Tests:
- `python3 tests/test_hkml_list.py`
- `./tests/run.sh`
- End-to-end Message-ID listing: fresh output reports row 8/index 2; cached output reports row 9/index 2, matching the actual target in both cases.