### PR TITLE
hkml_send: print mail before confirmation

### DIFF
--- a/src/hkml_send.py
+++ b/src/hkml_send.py
@@ -140,7 +140,7 @@ def send_mail(mboxfile, get_confirm, erase_mbox, orig_draft_subject=None):
         os.remove(mboxfile)
 
 def main(args):
-    send_mail(args.mbox_file, get_confirm=False, erase_mbox=False)
+    send_mail(args.mbox_file, get_confirm=True, erase_mbox=False)
 
 def set_argparser(parser=None):
     parser.description = 'send a mail'


### PR DESCRIPTION
hkml send captures git send-email's stdout
to parse the message id and the send result.
The capture also hides the recipient summary
and header preview and makes the [e]dit option
open an editor with no visible output.

The direct send path is the only one where the
user has to confirm without ever seeing the mail,
and it's also the path most likely to carry headers
the user didn't write by hand.

Print the email before handing it to git
send-email since git format-patch output carries
To/Cc headers the user can review before making
the decision.