### PR TITLE
hkml: add version command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hackermail"
-version = "0.1.0"
+version = "1.6.5"
 description = "HacKerMaiL (hkml) - a mails management tool for hackers who collaborate using mailing lists"
 license = "GPL-2.0-only"
 requires-python = ">=3.8"

--- a/src/hkml.py
+++ b/src/hkml.py
@@ -26,6 +26,7 @@ import hkml_manifest
 import hkml_cache
 import hkml_signature
 import hkml_config
+import hkml_version
 
 import _hkml
 
@@ -115,12 +116,15 @@ hkml_mail_note.set_argparser(parser_mail_note)
 parser_config = subparsers.add_parser('config', help='manage config')
 hkml_config.set_argparser(parser_config)
 
+parser_version = subparsers.add_parser('version', help='print version')
+hkml_version.set_argparser(parser_version)
+
 args = parser.parse_args()
 
 if args.directory is not None:
     os.chdir(args.directory)
 
-if not args.command in ['init', 'manifest']:
+if not args.command in ['init', 'manifest', 'version']:
     manifest = None
     if hasattr(args, 'manifest'):
         manifest = args.manifest

--- a/src/hkml_version.py
+++ b/src/hkml_version.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-2.0
+
+import os
+
+def get_version():
+    pyproject = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), 'pyproject.toml')
+    in_project = False
+    with open(pyproject) as f:
+        for line in f:
+            stripped = line.strip()
+            if stripped.startswith('['):
+                in_project = stripped == '[project]'
+                continue
+            if in_project and stripped.startswith('version'):
+                return stripped.split('=', 1)[1].strip().strip('"')
+    return 'unknown'
+
+def main(args):
+    print(get_version())
+
+def set_argparser(parser):
+    pass


### PR DESCRIPTION
Currently there is no way to check which version is installed.  This patch adds a 'version' subcommand that reads the version from pyproject.toml without needing the hkml metadata directory.  Register it in hkml.py and bypass the directory check, same as 'init' and 'manifest'.

Also bump the version in pyproject.toml to 1.6.5 to match the latest tag.